### PR TITLE
Add OSGI header manifest and update java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 
   <properties>
     <!-- maven-compiler-plugin configuration -->
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,23 +37,23 @@
 
   <scm>
     <connection>scm:git:git://github.com/EXIficient/exificient.git</connection>
-	<!-- <developerConnection>scm:git:git@github.com:EXIficient/exificient.git</developerConnection> -->
-	<developerConnection>scm:git:https://github.com/EXIficient/exificient.git</developerConnection>
+    <!-- <developerConnection>scm:git:git@github.com:EXIficient/exificient.git</developerConnection> -->
+    <developerConnection>scm:git:https://github.com/EXIficient/exificient.git</developerConnection>
     <url>https://github.com/EXIficient/exificient</url>
     <tag>HEAD</tag>
   </scm>
 
   <dependencies>
-	<dependency>
-	   <groupId>com.siemens.ct.exi</groupId>
-	   <artifactId>exificient-core</artifactId>
-	   <version>0.9.7-SNAPSHOT</version>
-	</dependency>
-	<dependency>
-	   <groupId>com.siemens.ct.exi</groupId>
-	   <artifactId>exificient-grammars</artifactId>
-	   <version>0.9.7-SNAPSHOT</version>
-	</dependency>
+    <dependency>
+       <groupId>com.siemens.ct.exi</groupId>
+       <artifactId>exificient-core</artifactId>
+       <version>0.9.7-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+       <groupId>com.siemens.ct.exi</groupId>
+       <artifactId>exificient-grammars</artifactId>
+       <version>0.9.7-SNAPSHOT</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -73,14 +73,6 @@
       <version>4.1.2</version>
       <scope>test</scope>
     </dependency>
-    <!-- Eclipse m2e -->
-    <!--
-	<dependency>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-resources-plugin</artifactId>
-		<version>2.5</version>
-	</dependency>
-	-->
   </dependencies>
 
   <properties>
@@ -144,7 +136,7 @@
         </executions>
       </plugin>
       <plugin>
-		<!-- without it Travis seems to pick Xmx32m which is not a lot -->
+        <!-- without it Travis seems to pick Xmx32m which is not a lot -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>EXIficient</name>
   <url>http://exificient.github.io/</url>
   <version>0.9.7-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <description>EXIficient is an open source implementation of the W3C Efficient XML Interchange
     (EXI) format specification written in the Java programming language. The EXI format is a very
     compact representation for the Extensible Markup Language (XML) Information Set that is intended
@@ -85,6 +85,23 @@
   <build>
     <finalName>exificient</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              com.siemens.ct.exi.api.*,
+              com.siemens.ct.exi.cmd.*,
+              com.siemens.ct.exi.util.*
+            </Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
       <!-- Include test classes -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In the provided PR we updated to the current java 8 version. 
Because if you used eclipse with version 5 as defined in the pom. There are some errors. 

And we added the OSGI header, so it is possible to use exificient in a karaf + cxf environment.

These are the same changes as in exificient-core, but for some strange reasons it replaces the complete file.