### PR TITLE
Do not retain decoder after parse

### DIFF
--- a/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
@@ -247,6 +247,8 @@ public class SAXDecoder implements XMLReader {
 
 		} catch (EXIException e) {
 			throw new SAXException("EXI " + e.getLocalizedMessage(), e);
+		} finally {
+			decoder = null;
 		}
 	}
 


### PR DESCRIPTION
Once we have parsed events, we will not need the decoder -- null
it out so users retaining SAXDecoder can garbage-collect it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>