### PR TITLE
Allow SAXDecoder.cbuffer to be managed by subclasses

### DIFF
--- a/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
@@ -82,8 +82,8 @@ public class SAXDecoder implements XMLReader {
 
 	protected static final String ATTRIBUTE_TYPE = "CDATA";
 
-	final static int DEFAULT_CHAR_BUFFER_SIZE = 4096;
-	protected char[] cbuffer = new char[DEFAULT_CHAR_BUFFER_SIZE];
+	protected static final int DEFAULT_CHAR_BUFFER_SIZE = 4096;
+	protected char[] cbuffer;
 
 	protected boolean namespaces = true;
 	protected boolean namespacePrefixes = false;
@@ -92,7 +92,7 @@ public class SAXDecoder implements XMLReader {
 	/* Helper for building strings */
 	protected StringBuilder sbHelper;
 
-	public SAXDecoder(EXIFactory noOptionsFactory) throws EXIException {
+	protected SAXDecoder(EXIFactory noOptionsFactory, char[] cbuffer) throws EXIException {
 		this.noOptionsFactory = noOptionsFactory;
 		if (noOptionsFactory.getSchemaIdResolver() == null) {
 			// set default schemaId resolver
@@ -111,6 +111,11 @@ public class SAXDecoder implements XMLReader {
 				FidelityOptions.FEATURE_PREFIX)) {
 			namespacePrefixes = true;
 		}
+		this.cbuffer = cbuffer;
+	}
+
+	public SAXDecoder(EXIFactory noOptionsFactory) throws EXIException {
+		this(noOptionsFactory, new char[DEFAULT_CHAR_BUFFER_SIZE]);
 	}
 
 	/*
@@ -508,7 +513,7 @@ public class SAXDecoder implements XMLReader {
 		attributes.clear();
 	}
 
-	private final void ensureBufferCapacity(int reqSize) {
+	protected void ensureBufferCapacity(int reqSize) {
 		if (reqSize > cbuffer.length) {
 			int newSize = cbuffer.length;
 

--- a/src/main/java/com/siemens/ct/exi/main/api/sax/SAXFactory.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/sax/SAXFactory.java
@@ -8,7 +8,7 @@ import com.siemens.ct.exi.core.exceptions.EXIException;
 
 public class SAXFactory {
 
-	final EXIFactory exiFactory;
+	protected final EXIFactory exiFactory;
 
 	public SAXFactory(EXIFactory exiFactory) {
 		this.exiFactory = exiFactory;


### PR DESCRIPTION
Users faced with a large number of concurrent SAXDecoder (or SAXFactory)
instances are hurt by the fact that SAXDecoder has an internally-managed
character buffer.

In these scenarios there are typically a few threads, hence at any given
point in time there are only a few character buffers used and the rest
of them are just sitting idle.

Expose just enough API surface so that users can subclass SAXDecoder,
override parse(InputSource) and ensureBufferCapacity(int) to implement
a buffer management strategy best suited for them -- like thread-local
buffer or shared buffer recycler.

Also relax visibility of SAXFactory.exiFactory, so it can be efficiently
subclassed to hand out customized SAXDecoder instances.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>