### PR TITLE
Handle IllegalArgumentException when decoding

### DIFF
--- a/data/bugs/gh33/Book2.dfdl.xsd
+++ b/data/bugs/gh33/Book2.dfdl.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+	xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  elementFormDefault="qualified">
+<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:annotation>
+		<xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat"/>
+			<dfdl:defineEscapeScheme name="Quotes">
+				<dfdl:escapeScheme
+					escapeKind="escapeBlock"
+					escapeBlockStart='"'
+					escapeBlockEnd='"'
+					escapeEscapeCharacter="\"
+					extraEscapedCharacters=""
+					generateEscapeBlock="whenNeeded"
+				/>
+			</dfdl:defineEscapeScheme>
+		</xs:appinfo>
+	</xs:annotation>
+	<xs:element name="CSV">
+		<xs:complexType>
+			<xs:sequence dfdl:separator="%NL;" dfdl:separatorPosition="infix" dfdl:separatorSuppressionPolicy="trailingEmpty">
+				<xs:element name="header">
+					<xs:complexType>
+						<xs:sequence dfdl:separator="," dfdl:separatorPosition="infix">
+							<xs:element name="title" maxOccurs="unbounded" type="xs:string" dfdl:lengthKind="delimited"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="row" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence dfdl:separator="," dfdl:separatorPosition="infix">
+							<xs:element name="field" minOccurs="11" maxOccurs="unbounded" type="xs:string" dfdl:lengthKind="delimited"
+								dfdl:escapeSchemeRef="Quotes"
+								dfdl:occursCount="{ fn:count(../../header/title) }"
+								dfdl:occursCountKind="expression" />
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/data/bugs/gh33/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
+++ b/data/bugs/gh33/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Intended for inclusion into other schemas. Has no targetNamespace on purpose -->
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+
+      <!--
+        This set of properties should never change. It can be added to 
+        if properties are missing, but should not be changed.
+        
+        Changes should be introduced by way of defining new formats in
+        terms of this one, which override definitions. See below in 
+        the file for examples. 
+       -->
+      <dfdl:defineFormat name="GeneralFormatOriginal">
+        <dfdl:format
+          alignment="1"
+          alignmentUnits="bytes"
+          binaryFloatRep="ieee"
+          binaryNumberCheckPolicy="lax"
+          binaryNumberRep="binary"
+          binaryCalendarEpoch="1970-01-01T00:00:00"
+          bitOrder="mostSignificantBitFirst"
+          byteOrder="bigEndian"
+          calendarCenturyStart="53"
+          calendarCheckPolicy="strict"
+          calendarDaysInFirstWeek="4"
+          calendarFirstDayOfWeek="Sunday"
+          calendarLanguage="en"
+          calendarObserveDST="yes"
+          calendarPatternKind="implicit"
+          calendarTimeZone=""
+          choiceLengthKind="implicit"
+          decimalSigned="yes"
+          documentFinalTerminatorCanBeMissing="no"
+          emptyValueDelimiterPolicy="both"
+          encodingErrorPolicy="replace"
+          encoding="US-ASCII"
+          escapeSchemeRef=""
+          fillByte="%#r20;"
+          floating="no"
+          ignoreCase="no"
+          initiatedContent="no"
+          initiator=""
+          leadingSkip="0"
+          lengthKind="implicit"
+          lengthUnits="bytes"
+          occursCountKind="implicit"
+          outputNewLine="%LF;"
+          representation="text"
+          separator=""
+          separatorPosition="infix"
+          separatorSuppressionPolicy="anyEmpty"
+          sequenceKind="ordered"
+          terminator=""
+          textBidi="no"
+          textBooleanPadCharacter="%SP;"
+          textCalendarJustification="left"
+          textCalendarPadCharacter="%SP;"
+          textNumberCheckPolicy="lax"
+          textNumberJustification="right"
+          textNumberPadCharacter="%SP;"
+          textNumberPattern="#,##0.###;-#,##0.###"
+          textNumberRep="standard"
+          textNumberRounding="explicit"
+          textNumberRoundingIncrement="0"
+          textNumberRoundingMode="roundHalfEven"
+          textOutputMinLength="0"
+          textPadKind="none"
+          textStandardBase="10"
+          textStandardDecimalSeparator="."
+          textStandardExponentRep="E"
+          textStandardGroupingSeparator=","
+          textStandardInfinityRep="Inf"
+          textStandardNaNRep="NaN"
+          textStandardZeroRep="0"
+          textStringJustification="left"
+          textStringPadCharacter="%SP;"
+          textTrimKind="none"
+          trailingSkip="0"
+          truncateSpecifiedLengthString="no"
+          utf16Width="fixed"
+        />
+      </dfdl:defineFormat>
+      
+      <dfdl:defineFormat name="GeneralFormat">
+        <dfdl:format ref="GeneralFormatOriginal" />
+      </dfdl:defineFormat>
+        
+      <dfdl:defineFormat name="GeneralFormatPortable">
+        <dfdl:format ref="GeneralFormatOriginal"
+          calendarTimeZone="UTC"
+          encodingErrorPolicy="error"
+        />   
+      </dfdl:defineFormat>
+
+    </xs:appinfo>
+  </xs:annotation>
+
+</xs:schema>

--- a/data/bugs/gh33/test_Book2.expected.xml
+++ b/data/bugs/gh33/test_Book2.expected.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<CSV>
+  <header>
+    <title>name prefix</title>
+    <title>name last</title>
+    <title>name first</title>
+    <title>name middle</title>
+    <title>name suffix</title>
+    <title>nickname</title>
+    <title>professional title</title>
+    <title>political title</title>
+    <title>rank political</title>
+    <title>rank military</title>
+    <title>gender</title>
+  </header>
+  <row>
+    <field></field>
+    <field>$B$2</field>
+    <field></field>
+    <field>$D$2</field>
+    <field>$E$2</field>
+    <field>$F$2</field>
+    <field>$G$2</field>
+    <field>$H$2</field>
+    <field>$I$2</field>
+    <field>$J$2</field>
+    <field>$K$2</field>
+  </row>
+  <row>
+    <field>$A$3</field>
+    <field></field>
+    <field>$C$3</field>
+    <field></field>
+    <field>$E$3</field>
+    <field>$F$3</field>
+    <field>$G$3</field>
+    <field>$H$3</field>
+    <field>$I$3</field>
+    <field>$J$3</field>
+    <field>$K$3</field>
+  </row>
+  <row>
+    <field>$A$4</field>
+    <field>$B$4</field>
+    <field></field>
+    <field>$D$4</field>
+    <field></field>
+    <field>$F$4</field>
+    <field>$G$4</field>
+    <field>$H$4</field>
+    <field>$I$4</field>
+    <field>$J$4</field>
+    <field>$K$4</field>
+  </row>
+  <row>
+    <field>$A$5</field>
+    <field>$B$5</field>
+    <field>$C$5</field>
+    <field></field>
+    <field>$E$5</field>
+    <field></field>
+    <field>$G$5</field>
+    <field>$H$5</field>
+    <field>$I$5</field>
+    <field>$J$5</field>
+    <field>$K$5</field>
+  </row>
+  <row>
+    <field>$A$6</field>
+    <field>$B$6</field>
+    <field>$C$6</field>
+    <field>$D$6</field>
+    <field></field>
+    <field>$F$6</field>
+    <field></field>
+    <field>$H$6</field>
+    <field>$I$6</field>
+    <field>$J$6</field>
+    <field>$K$6</field>
+  </row>
+  <row>
+    <field>$A$7</field>
+    <field>$B$7</field>
+    <field>$C$7</field>
+    <field>$D$7</field>
+    <field>$E$7</field>
+    <field></field>
+    <field>$G$7</field>
+    <field></field>
+    <field>$I$7</field>
+    <field>$J$7</field>
+    <field>$K$7</field>
+  </row>
+  <row>
+    <field>$A$8</field>
+    <field>$B$8</field>
+    <field>$C$8</field>
+    <field>$D$8</field>
+    <field>$E$8</field>
+    <field>$F$8</field>
+    <field></field>
+    <field>$H$8</field>
+    <field></field>
+    <field>$J$8</field>
+    <field>$K$8</field>
+  </row>
+  <row>
+    <field>$A$9</field>
+    <field>$B$9</field>
+    <field>$C$9</field>
+    <field>$D$9</field>
+    <field>$E$9</field>
+    <field>$F$9</field>
+    <field>$G$9</field>
+    <field></field>
+    <field>$I$9</field>
+    <field></field>
+    <field>$K$9</field>
+  </row>
+  <row>
+    <field>$A$10</field>
+    <field>$B$10</field>
+    <field>$C$10</field>
+    <field>$D$10</field>
+    <field>$E$10</field>
+    <field>$F$10</field>
+    <field>$G$10</field>
+    <field>$H$10</field>
+    <field></field>
+    <field>$J$10</field>
+    <field></field>
+  </row>
+  <row>
+    <field></field>
+    <field>$B$11</field>
+    <field>$C$11</field>
+    <field>$D$11</field>
+    <field>$E$11</field>
+    <field>$F$11</field>
+    <field>$G$11</field>
+    <field>$H$11</field>
+    <field>$I$11</field>
+    <field></field>
+    <field>$K$11</field>
+  </row>
+  <row>
+    <field>$A$12</field>
+    <field></field>
+    <field>$C$12</field>
+    <field>$D$12</field>
+    <field>$E$12</field>
+    <field>$F$12</field>
+    <field>$G$12</field>
+    <field>$H$12</field>
+    <field>$I$12</field>
+    <field>$J$12</field>
+    <field></field>
+  </row>
+</CSV>

--- a/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/sax/SAXDecoder.java
@@ -251,6 +251,10 @@ public class SAXDecoder implements XMLReader {
 
 		} catch (EXIException e) {
 			throw new SAXException("EXI " + e.getLocalizedMessage(), e);
+		} catch (IllegalArgumentException i) {
+			// This typically occurs when decoding a non-EXI file and we
+			// attempt to decode a byte that is not a valid Unicode code point
+			throw new SAXException("Error decoding EXI file: " + i.getLocalizedMessage());
 		}
 	}
 


### PR DESCRIPTION
IllegalArgumentException can happen when decoding a file, specifically when attempting to decode a schema aware file without using a schema aware decoder. This wasn't being cleanly handled before and as a result the exception was bubbling up into SAX and getting printed out to stderr regardless if the exception was being caught above SAX.

This commit catches the IllegalArgumentException and converts it to a SAXException, which is easier to deal with and can be handled in SAX by setting up and appropriate SAXErrorHandler.

https://github.com/EXIficient/exificient/issues/33