### PR TITLE
Migration to SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>exificient-grammars</artifactId>
       <version>1.0.5-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.6</version>
+    </dependency>
 	<dependency>
 	  <groupId>xmlpull</groupId>
 	  <artifactId>xmlpull</artifactId>
@@ -106,6 +111,12 @@
 		<artifactId>activation</artifactId>
 		<version>1.1.1</version>
 	</dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.6</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Eclipse m2e -->
     <!--

--- a/src/main/java/com/siemens/ct/exi/main/api/dom/DOMWriter.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/dom/DOMWriter.java
@@ -64,13 +64,13 @@ public class DOMWriter {
 	protected EXIBodyEncoder exiBody;
 
 	// attributes
-	private final AttributeList exiAttributes;
+	private AttributeList exiAttributes;
 
 	protected boolean preserveWhitespaces;
 	protected boolean preserveComments;
 	protected boolean preservePIs;
 
-	public DOMWriter(final EXIFactory factory) throws EXIException {
+	public DOMWriter(EXIFactory factory) throws EXIException {
 		this.factory = factory;
 
 		this.exiStream = factory.createEXIStreamEncoder();
@@ -86,11 +86,11 @@ public class DOMWriter {
 				FidelityOptions.FEATURE_PI);
 	}
 
-	public void setOutput(final OutputStream os) throws EXIException, IOException {
+	public void setOutput(OutputStream os) throws EXIException, IOException {
 		exiBody = exiStream.encodeHeader(os);
 	}
 
-	public void encode(final Document doc) throws EXIException, IOException {
+	public void encode(Document doc) throws EXIException, IOException {
 		if (exiBody == null) {
 			throw new EXIException("Please specify output stream");
 		}
@@ -105,7 +105,7 @@ public class DOMWriter {
 		exiBody.flush();
 	}
 
-	public void encodeFragment(final DocumentFragment docFragment)
+	public void encodeFragment(DocumentFragment docFragment)
 			throws EXIException, IOException {
 		if (exiBody == null) {
 			throw new EXIException("Please specify output stream");
@@ -117,7 +117,7 @@ public class DOMWriter {
 		exiBody.flush();
 	}
 
-	public void encode(final Node n) throws EXIException, IOException {
+	public void encode(Node n) throws EXIException, IOException {
 		if (n.getNodeType() == Node.DOCUMENT_NODE) {
 			encode((Document) n);
 		} else if (n.getNodeType() == Node.DOCUMENT_FRAGMENT_NODE) {
@@ -130,7 +130,7 @@ public class DOMWriter {
 		}
 	}
 
-	protected void encodeNode(final Node root) throws EXIException, IOException {
+	protected void encodeNode(Node root) throws EXIException, IOException {
 		assert (root.getNodeType() == Node.ELEMENT_NODE);
 
 		// start element
@@ -185,7 +185,7 @@ public class DOMWriter {
 		exiBody.encodeEndElement();
 	}
 
-	protected void encodeChildNodes(final NodeList children) throws EXIException,
+	protected void encodeChildNodes(NodeList children) throws EXIException,
 			IOException {
 		for (int i = 0; i < children.getLength(); i++) {
 			Node n = children.item(i);

--- a/src/main/java/com/siemens/ct/exi/main/api/dom/DOMWriter.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/dom/DOMWriter.java
@@ -26,6 +26,8 @@ package com.siemens.ct.exi.main.api.dom;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.DocumentType;
@@ -53,18 +55,22 @@ import com.siemens.ct.exi.core.values.StringValue;
  */
 
 public class DOMWriter {
+	
+	/** The logger used in this class. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(DOMWriter.class);
+
 	protected EXIFactory factory;
 	protected EXIStreamEncoder exiStream;
 	protected EXIBodyEncoder exiBody;
 
 	// attributes
-	private AttributeList exiAttributes;
+	private final AttributeList exiAttributes;
 
 	protected boolean preserveWhitespaces;
 	protected boolean preserveComments;
 	protected boolean preservePIs;
 
-	public DOMWriter(EXIFactory factory) throws EXIException {
+	public DOMWriter(final EXIFactory factory) throws EXIException {
 		this.factory = factory;
 
 		this.exiStream = factory.createEXIStreamEncoder();
@@ -80,11 +86,11 @@ public class DOMWriter {
 				FidelityOptions.FEATURE_PI);
 	}
 
-	public void setOutput(OutputStream os) throws EXIException, IOException {
+	public void setOutput(final OutputStream os) throws EXIException, IOException {
 		exiBody = exiStream.encodeHeader(os);
 	}
 
-	public void encode(Document doc) throws EXIException, IOException {
+	public void encode(final Document doc) throws EXIException, IOException {
 		if (exiBody == null) {
 			throw new EXIException("Please specify output stream");
 		}
@@ -99,7 +105,7 @@ public class DOMWriter {
 		exiBody.flush();
 	}
 
-	public void encodeFragment(DocumentFragment docFragment)
+	public void encodeFragment(final DocumentFragment docFragment)
 			throws EXIException, IOException {
 		if (exiBody == null) {
 			throw new EXIException("Please specify output stream");
@@ -111,7 +117,7 @@ public class DOMWriter {
 		exiBody.flush();
 	}
 
-	public void encode(Node n) throws EXIException, IOException {
+	public void encode(final Node n) throws EXIException, IOException {
 		if (n.getNodeType() == Node.DOCUMENT_NODE) {
 			encode((Document) n);
 		} else if (n.getNodeType() == Node.DOCUMENT_FRAGMENT_NODE) {
@@ -124,7 +130,7 @@ public class DOMWriter {
 		}
 	}
 
-	protected void encodeNode(Node root) throws EXIException, IOException {
+	protected void encodeNode(final Node root) throws EXIException, IOException {
 		assert (root.getNodeType() == Node.ELEMENT_NODE);
 
 		// start element
@@ -179,7 +185,7 @@ public class DOMWriter {
 		exiBody.encodeEndElement();
 	}
 
-	protected void encodeChildNodes(NodeList children) throws EXIException,
+	protected void encodeChildNodes(final NodeList children) throws EXIException,
 			IOException {
 		for (int i = 0; i < children.getLength(); i++) {
 			Node n = children.item(i);
@@ -227,7 +233,7 @@ public class DOMWriter {
 				}
 				break;
 			default:
-				System.err.println("[WARNING] Unhandled DOM NodeType: "
+				LOGGER.error("[WARNING] Unhandled DOM NodeType: "
 						+ n.getNodeType());
 				// throw new EXIException("Unknown NodeType? " +
 				// n.getNodeType());

--- a/src/main/java/com/siemens/ct/exi/main/api/stream/StAXEncoder.java
+++ b/src/main/java/com/siemens/ct/exi/main/api/stream/StAXEncoder.java
@@ -46,6 +46,8 @@ import javax.xml.stream.events.ProcessingInstruction;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import com.siemens.ct.exi.core.Constants;
@@ -69,6 +71,9 @@ import com.siemens.ct.exi.main.util.SimpleDocTypeParser;
  */
 
 public class StAXEncoder implements XMLStreamWriter {
+
+	/** The logger used in this class. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(StAXEncoder.class);
 
 	protected EXIBodyEncoder encoder;
 	protected EXIStreamEncoder exiStream;
@@ -192,7 +197,7 @@ public class StAXEncoder implements XMLStreamWriter {
 				this.writeEntityRef(er.getName());
 				break;
 			default:
-				System.out.println("StAX Event '" + event + "' not supported!");
+				LOGGER.warn("StAX Event '{}' not supported!", event);
 			}
 		}
 
@@ -271,7 +276,7 @@ public class StAXEncoder implements XMLStreamWriter {
 				// TODO ER
 				break;
 			default:
-				System.out.println("Event '" + event + "' not supported!");
+				LOGGER.warn("Event '{}' not supported!", event);
 			}
 		}
 


### PR DESCRIPTION
Use of SLF4J logger instead of System.(out|err).println()